### PR TITLE
fix: Use explicit .tsx extension in imports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
-import { LifeDataProvider, useLifeData } from './hooks/useLifeData';
-import { AuthProvider, useAuth } from './hooks/useAuth';
+import { LifeDataProvider, useLifeData } from './hooks/useLifeData.tsx';
+import { AuthProvider, useAuth } from './hooks/useAuth.tsx';
 import OnboardingView from './components/views/OnboardingView';
 import DashboardView from './components/views/DashboardView';
 import AuthView from './components/views/AuthView';

--- a/components/views/DashboardView.tsx
+++ b/components/views/DashboardView.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useState, useMemo } from 'react';
-import { useLifeData } from '../../hooks/useLifeData';
-import { useAuth } from '../../hooks/useAuth';
+import { useLifeData } from '../../hooks/useLifeData.tsx';
+import { useAuth } from '../../hooks/useAuth.tsx';
 import { supabase } from '../../lib/supabaseClient';
 import ControlPanel from '../dashboard/ControlPanel';
 import LifeOrb3D from '../dashboard/LifeOrb3D';

--- a/components/views/OnboardingView.tsx
+++ b/components/views/OnboardingView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLifeData } from '../../hooks/useLifeData';
+import { useLifeData } from '../../hooks/useLifeData.tsx';
 import type { LifeData, ActivityData } from '../../types';
 import Button from '../ui/Button';
 import Card from '../ui/Card';


### PR DESCRIPTION
This commit updates all imports of `useAuth` and `useLifeData` to use the `.tsx` file extension explicitly. This is a workaround to force the Vercel build system to recognize the renamed files and resolve the build error.